### PR TITLE
add test server

### DIFF
--- a/bin/www
+++ b/bin/www
@@ -20,7 +20,7 @@ app.set("port", port);
  * Connect to MongoDB
  **/
 
-var mongoDbUrl = process.env.MONGODB_URL || "mongodb://0.0.0.0/forget_me_not_test";
+var mongoDbUrl = process.env.MONGODB_URL || "mongodb://0.0.0.0/forget_me_not";
 mongoose.connect(mongoDbUrl, {
   useNewUrlParser: true,
   useUnifiedTopology: true,

--- a/bin/www
+++ b/bin/www
@@ -20,7 +20,7 @@ app.set("port", port);
  * Connect to MongoDB
  **/
 
-var mongoDbUrl = process.env.MONGODB_URL || "mongodb://0.0.0.0/forget_me_not";
+var mongoDbUrl = process.env.MONGODB_URL || "mongodb://0.0.0.0/forget-me-not";
 mongoose.connect(mongoDbUrl, {
   useNewUrlParser: true,
   useUnifiedTopology: true,

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "start": "node ./bin/www",
     "nodemon": "nodemon ./bin/www",
-    "start:test": "PORT=3030 MONGODB_URL='mongodb://0.0.0.0/forget_me_not_test' npm start",
+    "start:test": "PORT=3030 MONGODB_URL='mongodb://0.0.0.0/forget-me-not-test' npm start",
     "test:unit": "jest"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "start": "node ./bin/www",
     "nodemon": "nodemon ./bin/www",
-    "start:test": "PORT=3030 MONGODB_URL='mongodb://0.0.0.0/acebook_test' npm start",
+    "start:test": "PORT=3030 MONGODB_URL='mongodb://0.0.0.0/forget_me_not_test' npm start",
     "test:unit": "jest"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "private": true,
   "scripts": {
     "start": "node ./bin/www",
-    "nodemon": "nodemon ./bin/www"
+    "nodemon": "nodemon ./bin/www",
+    "start:test": "PORT=3030 MONGODB_URL='mongodb://0.0.0.0/acebook_test' npm start",
+    "test:unit": "jest"
   },
   "dependencies": {
     "cookie-parser": "~1.4.4",

--- a/spec/mongodb_helper.js
+++ b/spec/mongodb_helper.js
@@ -1,7 +1,7 @@
 var mongoose = require("mongoose");
 
 beforeAll(function (done) {
-  mongoose.connect("mongodb://0.0.0.0/forget-me-not_test", {
+  mongoose.connect("mongodb://0.0.0.0/forget-me-not-test", {
     useNewUrlParser: true,
     useUnifiedTopology: true,
   });


### PR DESCRIPTION
Adds a test server which uses a test database.

npm start will run a server on localhost:3000, using a database name forget-me-not (which you will have to create).

npm run start:test will run a server on localhost:3030, using a database named forget-me-not-test.